### PR TITLE
Depend on only one version of winapi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,5 @@ license = "MIT/Apache-2.0"
 
 [target."cfg(windows)".dependencies]
 scopeguard = "0.3"
-winapi = { version = "0.3", features = ["errhandlingapi", "handleapi", "processthreadsapi", "std", "winerror", "winnt"] }
-userenv-sys = "0.2.0"
+winapi = { version = "0.3", features = ["errhandlingapi", "handleapi", "processthreadsapi", "std", "winerror", "winnt", "userenv"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,6 @@
 extern crate scopeguard;
 #[cfg(windows)]
 extern crate winapi;
-#[cfg(windows)]
-extern crate userenv;
 
 #[cfg(windows)]
 use winapi::shared::minwindef::DWORD;
@@ -68,7 +66,7 @@ pub fn home_dir() -> Option<PathBuf> {
 #[cfg(windows)]
 fn home_dir_() -> Option<PathBuf> {
     use std::ptr;
-    use userenv::GetUserProfileDirectoryW;
+    use winapi::um::userenv::GetUserProfileDirectoryW;
     use winapi::shared::winerror::ERROR_INSUFFICIENT_BUFFER;
     use winapi::um::errhandlingapi::GetLastError;
     use winapi::um::handleapi::CloseHandle;


### PR DESCRIPTION
before winapi 0.2 and 0.3 was used due to userenv-sys depends on winapi 0.2
cc @alexcrichton