### PR TITLE
Add `home_dir` for WASI

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,11 @@ pub fn home_dir() -> Option<PathBuf> {
 #[cfg(windows)]
 use windows::home_dir_inner;
 
+#[cfg(target_os = "wasi")]
+fn home_dir_inner() -> Option<PathBuf> {
+    env::var_os("HOME").map(PathBuf::from)
+}
+
 #[cfg(any(unix, target_os = "redox"))]
 fn home_dir_inner() -> Option<PathBuf> {
     #[allow(deprecated)]


### PR DESCRIPTION
This PR adds `home_dir` implementation for Web Assembly System Interface (WASI) target, that uses `HOME` environment variable. Since WASI lacks concept of user, I think this is the way to go.

Lacking this function makes porting binaries to WASI unnecessarily harder.
